### PR TITLE
Add docstrings, improve documentation, and fix some minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cljs Web3
 
-Clojurescript API for [Ethereum](https://ethereum.org/) blockchain [Web3 API](https://github.com/ethereum/wiki/wiki/JavaScript-API)
+ClojureScript API for [Ethereum](https://ethereum.org/) blockchain [Web3 API](https://github.com/ethereum/wiki/wiki/JavaScript-API)
 
 ## See also
 * [How to create decentralised apps with Clojurescript re-frame and Ethereum](https://medium.com/@matus.lestan/how-to-create-decentralised-apps-with-clojurescript-re-frame-and-ethereum-81de24d72ff5#.kul24x62l)
@@ -8,25 +8,25 @@ Clojurescript API for [Ethereum](https://ethereum.org/) blockchain [Web3 API](ht
 
 ## Installation
 ```clojure
-; Add to dependencies
+;; Add to dependencies
 [cljs-web3 "0.19.0-0-5"]
 ```
 ```clojure
 (ns my.app
   (:require [cljsjs.web3] ; You only need this, if you don't use MetaMask extension or Mist browser
-            [cljs-web3.core :as web3]
-            [cljs-web3.eth :as web3-eth]
-            [cljs-web3.db :as web3-db]
-            [cljs-web3.personal :as web3-personal]
-            [cljs-web3.shh :as web3-shh]
-            [cljs-web3.net :as web3-net]
             [cljs-web3.bzz :as web3-bzz]
+            [cljs-web3.core :as web3]
+            [cljs-web3.db :as web3-db]
+            [cljs-web3.eth :as web3-eth]
             [cljs-web3.evm :as web3-evm]
-            [cljs-web3.settings :as web3-settings]))
+            [cljs-web3.net :as web3-net]
+            [cljs-web3.personal :as web3-personal]
+            [cljs-web3.settings :as web3-settings]
+            [cljs-web3.shh :as web3-shh]))
 ```
-r
+
 ## Usage
-So basically, stick with Web3 API [docs](https://github.com/ethereum/wiki/wiki/JavaScript-API), all methods there have their kebab-case version in this library. Also, return values and responses in callbacks are automatically kebab-cased and keywordized. Instead of calling method of web3 object, you pass it as a first argument. For example:
+So basically, stick with the Web3 API [docs](https://github.com/ethereum/wiki/wiki/JavaScript-API), all methods there have their kebab-cased version in this library. Also, return values and responses in callbacks are automatically kebab-cased and keywordized. Instead of calling method of the web3 object, you pass it as a first argument. For example:
 ```javascript
 web3.eth.accounts
 web3.version.api
@@ -45,7 +45,7 @@ becomes
 (web3-net/peer-count web3 (fn [error result]))
 ```
 
-Some functions in `cljs-web3.core` don't really need web3 instance, even though they're called as object methods in Web3 docs. To make our lives easier, in clojurescript, you can just call it without web3 instance. For example:
+Some functions in `cljs-web3.core` don't really need a web3 instance, even though they're called as object methods in Web3 docs. To make our lives easier, in ClojureScript, you can just call it without a web3 instance. For example:
 ```
 (web3/sha3 "1")
 => 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6
@@ -54,36 +54,35 @@ Some functions in `cljs-web3.core` don't really need web3 instance, even though 
 (web3/to-wei 1 :ether)
 => "1000000000000000000"
 ```
-#### Extra functions for better life
-Thses are few extra functions, which you won't find in Web3 API
+#### Extra functions for a better life
+These are a few extra functions, which you won't find in the Web3 API:
 ```clojure
-; Create web3 instance
+;; Create web3 instance
 (web3/create-web3 "http://localhost:8545/")
 
-; Deploy new contract
+;; Deploy new contract
 (web3-eth/contract-new web3 abi
   {:data bin
    :gas gas-limit
    :from (first (web3-eth/accounts w3))}
   (fn [err res]))
-  
-; Create contract instance from already deployed contract
+
+;; Create contract instance from already deployed contract
 (web3-eth/contract-at web3 abi address)
 
-; This way you can call any contract method
+;; This way you can call any contract method
 (web3-eth/contract-call ContractInstance :multiply 5)
 
-; This library cointains special namespace cljs-web3.evm for controlling testrpc server
-; See https://github.com/ethereumjs/testrpc for more info
-(web3-evm/increase-time! web3 [1000] callback) 
-(web3-evm/mine! web3 callback) 
-(web3-evm/revert! web3 [0x01] callback) 
-(web3-evm/snapshot! web3 callback) 
+;; This library contains the special namespace cljs-web3.evm for controlling a testrpc server
+;; See https://github.com/ethereumjs/testrpc for more info
+(web3-evm/increase-time! web3 [1000] callback)
+(web3-evm/mine! web3 callback)
+(web3-evm/revert! web3 [0x01] callback)
+(web3-evm/snapshot! web3 callback)
 ```
 
 #### cljs.core.async integration
-There's alternative async namespace for each original namespace, which provides async alternative instead of callback
-approach. For example:
+There's an alternative async namespace for each original namespace, which provides an async alternative instead of the callback approach. For example:
 ```clojure
 (ns test
   (:require
@@ -91,25 +90,25 @@ approach. For example:
     [cljs.core.async :refer [<! >! chan]]
     [clojure.string :as string])
   (:require-macros [cljs.core.async.macros :refer [go]]))
-  
+
 (go
   (<! (web3-eth-async/accounts web3))
   ;; returns [nil ["0x56727ca3132d00307051a4fa6c6a2c3f07cb3f91"]]
-  
-  ;; Alternatively, you can always pass channel as first argument. Response will be pushed into this channel
-  ;; For example if you need pass channel with transducers
+
+  ;; Alternatively, you can always pass a core.async channel as a first argument. The response will be put onto this channel
+  ;; For example, if you pass a channel with a transducer:
   (<! (web3-eth-async/accounts
             (chan 1 (comp (map second)
                           (map (partial map string/upper-case))))
             web3))
   ;; returns ("0X56727CA3132D00307051A4FA6C6A2C3F07CB3F91")
-  
+
   )
 ```
 
 
 #### Code is documentation
-Don't hesitate to open lib files or test file of this library to see how to use it. It's not bloated with implementation, so it's easy to read.
+Don't hesitate to open lib files or test files of this library to see how to use it. It's not bloated with implementation, so it's easy to read.
 
 ## DAPPS using cljs-web3
 * [emojillionaire](https://github.com/madvas/emojillionaire)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ There's an alternative async namespace for each original namespace, which provid
 #### Code is documentation
 Don't hesitate to open lib files or test files of this library to see how to use it. It's not bloated with implementation, so it's easy to read.
 
+Docstrings for the methods and namespaces are adjusted to ClojureScript from the [web3.js documentation](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3netlistening)
 ## DAPPS using cljs-web3
 * [emojillionaire](https://github.com/madvas/emojillionaire)
 * [ethlance](https://github.com/madvas/ethlance)

--- a/src/cljs_web3/bzz.cljs
+++ b/src/cljs_web3/bzz.cljs
@@ -1,4 +1,6 @@
 (ns cljs-web3.bzz
+  "Interface to the web3-bzz that allows you to interact with swarm
+  decentralized file store"
   (:refer-clojure :exclude [get])
   (:require [cljs-web3.utils :as u :refer [js-apply]]))
 
@@ -37,12 +39,3 @@
 
 (defn sync-enabled? [web3 & args]
   (js-apply (get-bzz web3) "syncEnabled" args))
-
-
-
-
-
-
-
-
-

--- a/src/cljs_web3/core.cljs
+++ b/src/cljs_web3/core.cljs
@@ -1,89 +1,393 @@
 (ns cljs-web3.core
+  "ClojureScript wrapper around Web3 JavaScript API methods on the Web3 object.
+
+  A `web3-instance` can be obtained in two ways:
+
+  1. Via the user's browser (when using Mist or MetaMask)
+
+  `(defn web3-instance []
+     (new (aget js/window \"Web3\")
+          (current-provider (aget js/window \"web3\"))))`
+
+  2. Created via `create-web3` (when running a local Ethereum node)
+
+  `(def web3-instance
+     (create-web3 \"http://localhost:8545/\"))`
+
+  The Web3 JavaScript object is provided on the browser window."
   (:require [cljs-web3.utils :as u :refer [js-apply js-prototype-apply]]))
 
-(def version-api (u/prop-or-clb-fn "version" "api"))
-(def version-node (u/prop-or-clb-fn "version" "node"))
-(def version-network (u/prop-or-clb-fn "version" "network"))
-(def version-ethereum (u/prop-or-clb-fn "version" "ethereum"))
-(def version-whisper (u/prop-or-clb-fn "version" "whisper"))
 
-(defn connected? [web3]
+(def version-api
+  "Returns a string representing the Ethereum js api version.
+
+  Parameters:
+  Web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(web3/version-node web3-instance
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 0.2.0"
+  (u/prop-or-clb-fn "version" "api"))
+
+
+(def version-node
+  "Returns a string representing the client/node version.
+
+  Parameters:
+  Web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(version-node web3-instance
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> MetaMask/v3.10.8"
+  (u/prop-or-clb-fn "version" "node"))
+
+
+(def version-network
+  "Returns a string representing the network protocol version.
+
+  \"1\"  is Main Net or Local Net
+  \"2\"  is (Deprecated) Morden Network
+  \"3\"  is Ropsten Test Net
+  \"4\"  is Rinkeby Test Net
+  \"42\" is Kovan Test Net
+
+  Parameters:
+  Web3        - Web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(version-network web3-instance
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 3"
+  (u/prop-or-clb-fn "version" "network"))
+
+(def version-ethereum
+  "Returns a hexadecimal string representing the Ethereum protocol version.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(version-ethereum web3-instance
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 0x3f"
+  (u/prop-or-clb-fn "version" "ethereum"))
+
+
+(def version-whisper
+  "Returns a string representing the Whisper protocol version.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(version-whisper
+           web3-instance
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 20"
+  (u/prop-or-clb-fn "version" "whisper"))
+
+
+(defn connected?
+  "Returns a boolean indicating if a connection to a node exists.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Example:
+  user> `(connected? web3-instance)`
+  true"
+  [web3]
   (js-apply web3 "isConnected"))
 
+
 (defn sha3
+  "Returns a string representing the Keccak-256 SHA3 of the given data.
+
+  Parameters:
+  String - The string to hash using the Keccak-256 SHA3 algorithm
+  Map    - (optional) Set encoding to hex if the string to hash is encoded
+                      in hex. A leading 0x will be automatically ignored.
+  Web3   - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> (def hash \"Some string to be hashed\")
+  #'user/hash
+  user> `(sha3 hash)
+  \"0xed973b234cf2238052c9ac87072c71bcf33abc1bbd721018e0cca448ef79b379\"`
+  user> `(sha3 hash {:encoding :hex})`
+  \"0xbd83a94d23235dd7dfcf67a5a0d9e9643a715cd5b528083a2cf944d61f8e7b51\"
+
+  NOTE: This differs from the documented result of the Web3 JavaScript API,
+  which equals
+  \"0x85dd39c91a64167ba20732b228251e67caed1462d4bcf036af88dc6856d0fdcc\""
   ([string] (sha3 string nil))
   ([string options] (sha3 js/Web3 string options))
   ([Web3 string options]
    (js-prototype-apply Web3 "sha3" [string options])))
 
+
 (defn to-hex
+  "Returns hexadecimal string representation of any value
+  string|number|map|set|BigNumber.
+
+  Parameters:
+  Any  - The value to parse
+  Web3 - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(to-hex \"foo\")`
+  \"0x666f6f\" "
   ([any] (to-hex js/Web3 any))
   ([Web3 any]
    (js-prototype-apply Web3 "toHex" [any])))
 
+
 (defn to-ascii
+  "Converts a HEX string into a ASCII string.
+
+  Parameters:
+  hex-string - A HEX string to be converted to ASCII.
+  Web3       - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(to-ascii \"0x666f6f\")`
+  \"foo\" "
   ([hex-string] (to-ascii js/Web3 hex-string))
   ([Web3 hex-string]
    (js-prototype-apply Web3 "toAscii" [hex-string])))
 
+
 (defn from-ascii
+  "Converts any ASCII string to a HEX string.
+
+  Parameters:
+  string  - An ASCII string to be converted to HEX.
+  padding - (optional) The number of bytes the returned HEX string should have.
+  Web3    - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(from-ascii \"ethereum\")`
+  \"0x657468657265756d\"
+  user> `(from-ascii \"ethereum\")`
+  \"0x657468657265756d000000000000000000000000000000000000000000000000\"
+
+  NOTE: The latter is intended behaviour. Because of a bug in Web3 the padding
+        is not added. See https://github.com/ethereum/web3.js/issues/337"
   ([string] (from-ascii string nil))
   ([string padding] (from-ascii js/Web3 string padding))
   ([Web3 string padding]
    (js-prototype-apply Web3 "fromAscii" [string padding])))
 
+
 (defn to-decimal
+  "Returns the number representing a HEX string in its number representation.
+
+  Parameters:
+  hex-string - An HEX string to be converted to a number.
+  Web3       - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(to-decimal \"0x15\")`
+  21"
   ([hex-string] (to-decimal js/Web3 hex-string))
   ([Web3 hex-string]
    (js-prototype-apply Web3 "toDecimal" [hex-string])))
 
 (defn from-decimal
+  "Converts a number or number string to its HEX representation.
+
+  Parameters:
+  number - A number to be converted to a HEX string.
+  Web3   - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user-> `(web3/from-decimal 21)`
+  \"0x15\""
   ([number] (from-decimal js/Web3 number))
   ([Web3 number]
    (js-prototype-apply Web3 "fromDecimal" [number])))
 
 (defn from-wei
+  "Converts a number of Wei into an Ethereum unit.
+
+  Parameters:
+  number - A number or BigNumber instance.
+  unit   - One of :noether :wei :kwei :Kwei :babbage :femtoether :mwei :Mwei
+           :lovelace :picoether :gwei :Gwei :shannon :nanoether :nano :szabo
+           :microether :micro :finney :milliether :milli :ether :kether :grand
+           :mether :gether :tether
+  Web3   - (optional first argument) Web3 JavaScript object.
+
+  Returns either a number string, or a BigNumber instance, depending on the
+  given number parameter.
+
+  Example:
+  user> `(web3/from-wei 10 :ether)`
+  \"0.00000000000000001\""
   ([number unit] (from-wei js/Web3 number unit))
   ([Web3 number unit]
    (js-prototype-apply Web3 "fromWei" [number (name unit)])))
 
 (defn to-wei
+  "Converts an Ethereum unit into Wei.
+
+  Parameters:
+  number - A number or BigNumber instance.
+  unit   - One of :noether :wei :kwei :Kwei :babbage :femtoether :mwei :Mwei
+           :lovelace :picoether :gwei :Gwei :shannon :nanoether :nano :szabo
+           :microether :micro :finney :milliether :milli :ether :kether :grand
+           :mether :gether :tether
+  Web3   - (optional first argument) Web3 JavaScript object.
+
+  Returns either a number string, or a BigNumber instance, depending on the
+  given number parameter.
+
+  Example:
+  user> `(web3/to-wei 10 :ether)`
+  \"10000000000000000000\""
   ([number unit] (to-wei js/Web3 number unit))
   ([Web3 number unit]
    (js-prototype-apply Web3 "toWei" [number (name unit)])))
 
 (defn to-big-number
+  "Converts a given number into a BigNumber instance.
+
+  Parameters:
+  number-or-hex-string - A number, number string or HEX string of a number.
+  Web3                 - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(to-big-number \"10000000000000000000\")`
+  <An instance of BigNumber>"
   ([number-or-hex-string] (to-big-number js/Web3 number-or-hex-string))
   ([Web3 number-or-hex-string]
    (js-prototype-apply Web3 "toBigNumber" [number-or-hex-string])))
 
 (defn pad-left
+  "Returns input string with zeroes or sign padded to the left.
+
+  Parameters:
+  string - String to be padded
+  chars  - Amount of chars to address
+  sign   - (optional) Char to pad with (behaviour with multiple chars is
+                      undefined)
+  Web3   - (optional first argument) Web3 JavaScript object.
+
+  Example:
+  user> `(web3/pad-left \"foo\" 8)`
+  \"00000foo\"
+  user> `(web3/pad-left \"foo\" 8 \"b\")`
+  \"bbbbbfoo\" "
   ([string chars] (pad-left string chars nil))
   ([string chars sign] (pad-left js/Web3 string chars sign))
   ([Web3 string chars sign]
    (js-prototype-apply Web3 "padLeft" [string chars sign])))
 
 (defn pad-right
+  "Returns input string with zeroes or sign padded to the right.
+
+  Parameters:
+  string - String to be padded
+  chars  - Amount of total chars
+  sign   - (optional) Char to pad with (behaviour with multiple chars is
+                      undefined)
+  Web3   - (optional first argument) Web3 instance
+
+  Example:
+  user> `(web3/pad-right \"foo\" 8)`
+  \"foo00000\"
+  user> `(web3/pad-right \"foo\" 8 \"b\")`
+  \"foobbbbb\" "
   ([string chars] (pad-right string chars nil))
   ([string chars sign] (pad-right js/Web3 string chars sign))
   ([Web3 string chars sign]
    (js-prototype-apply Web3 "padRight" [string chars sign])))
 
 (defn address?
+  "Returns a boolean indicating if the given string is an address.
+
+  Parameters:
+  address - An HEX string.
+  Web3    - (Optional first argument) Web3 JavaScript object
+
+  Returns false if it's not on a valid address format. Returns true if it's an
+  all lowercase or all uppercase valid address. If it's a mixed case address, it
+  checks using web3's isChecksumAddress().
+
+  Example:
+  user> `(address? \"0x8888f1f195afa192cfee860698584c030f4c9db1\")`
+  true
+
+  ;; With first f capitalized
+  user> `(web3/address? \"0x8888F1f195afa192cfee860698584c030f4c9db1\")`
+  false"
   ([address] (address? js/Web3 address))
   ([Web3 address]
    (js-prototype-apply Web3 "isAddress" [address])))
 
-(defn reset [web3]
-  (js-apply web3 "reset"))
+(defn reset
+  "Should be called to reset the state of web3. Resets everything except the manager.
+  Uninstalls all filters. Stops polling.
 
-(defn set-provider [web3 provider]
+  Parameters:
+  web3             - An instance of web3
+  keep-is-syncing? - If true it will uninstall all filters, but will keep the
+                     web3.eth.isSyncing() polls
+
+  Returns nil.
+
+  Example:
+  user> `(reset web3-instance true)`
+  nil"
+  ([web3]
+   (reset web3 false))
+  ([web3 keep-is-syncing?]
+   (js-apply web3 "reset" [keep-is-syncing?])))
+
+(defn set-provider
+  "Should be called to set provider.
+
+  Parameters:
+  web3     - Web3 instance
+  provider - the provider
+
+  Available providers in web3-cljs:
+  - `http-provider`
+  - `ipc-provider`
+
+  Example:
+  user> `(set-provider web3-instance
+                       (http-provider web3-instance \"http://localhost:8545\"))`
+  nil"
+  [web3 provider]
   (js-apply web3 "setProvider" [provider]))
 
-(defn current-provider [web3]
+(defn current-provider
+  "Will contain the current provider, if one is set. This can be used to check
+  if Mist etc. already set a provider.
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns the provider set or nil."
+  [web3]
   (aget web3 "currentProvider"))
 
-;; Providers
+
+;;; Providers
 
 (defn http-provider [Web3 uri]
   (let [constructor (aget Web3 "providers" "HttpProvider")]
@@ -94,6 +398,15 @@
     (constructor. uri)))
 
 (defn create-web3
+  "Creates a web3 instance using an `http-provider`.
+
+  Parameters:
+  url  - The URL string for which to create the provider.
+  Web3 - (Optional first argument) Web3 JavaScript object
+
+  Example:
+  user> `(create-web3 \"http://localhost:8545/\")`
+  <web3 instance>"
   ([url] (create-web3 js/Web3 url))
   ([Web3 url]
    (new Web3 (http-provider Web3 url))))

--- a/src/cljs_web3/db.cljs
+++ b/src/cljs_web3/db.cljs
@@ -1,17 +1,71 @@
 (ns cljs-web3.db
+  "Functions on LevelDB.
+
+  A fast key-value storage library that provides an ordered mapping from string
+  keys to string values."
   (:require [cljs-web3.utils :as u :refer [js-apply]]))
 
-(defn get-db [web3]
+
+(defn get-db
+  "Gets leveldb object from web3-instance.
+
+  Parameter:
+  web3 - web3 instance"
+  [web3]
   (aget web3 "db"))
 
-(defn put-string! [web3 & [db key value :as args]]
+
+(defn put-string!
+  "This method should be called, when we want to store a string in the local
+  leveldb database.
+
+  Parameters:
+  web3 - web3 instance
+  args:
+    db    - The database (string) to store to.
+    key   - The name (string) of the store.
+    value - The string value to store.
+
+  Returns true if successful, otherwise false."
+  [web3 & [db key value cb :as args]]
   (js-apply (get-db web3) "putString" args))
 
-(defn get-string [web3 & [db key :as args]]
+
+(defn get-string
+  "This method should be called, when we want to get string from the local
+  leveldb database.
+
+  Parameters:
+  db  - The database (string) name to retrieve from.
+  key - The name (string) of the store.
+
+  Returns the stored value string."
+  [web3 & [db key :as args]]
   (js-apply (get-db web3) "getString" args))
 
-(defn put-hex! [web3 & [db key value :as args]]
+
+(defn put-hex!
+  "This method should be called, when we want to store binary data in HEX form
+  in the local leveldb database.
+
+  Parameters:
+  db    - The database (string) to store to.
+  key   - The name (string) of the store.
+  value - The HEX string to store.
+
+  Returns true if successful, otherwise false."
+  [web3 & [db key value :as args]]
   (js-apply (get-db web3) "putHex" args))
 
-(defn get-hex [web3 & [db key :as args]]
+
+(defn get-hex
+  "This method should be called, when we want to get a binary data in HEX form
+  from the local leveldb database.
+
+  Parameters:
+  db  - The database (string) to store to.
+  key - The name (string) of the store.
+
+  Returns the stored HEX value."
+  [web3 & [db key :as args]]
   (js-apply (get-db web3) "getHex" args))

--- a/src/cljs_web3/eth.cljs
+++ b/src/cljs_web3/eth.cljs
@@ -53,6 +53,8 @@
 
 (defn get-block-transaction-count [web3 & [block-hash-or-number :as args]]
   (eth web3) "getBlockTransactionCount" args)
+  [web3 & [block-hash-or-number :as args]]
+  (js-apply (eth web3) "getBlockTransactionCount" args))
 
 (defn get-uncle [web3 & [block-hash-or-number uncle-number return-transaction-objects? :as args]]
   (js-apply (eth web3) "getUncle" args))

--- a/src/cljs_web3/eth.cljs
+++ b/src/cljs_web3/eth.cljs
@@ -75,6 +75,7 @@
   (js-apply (eth web3) "sendTransaction" args))
 
 (defn send-raw-transaction! [web3 & [signed-transaction-data & args]]
+  [web3 & [signed-transaction-data :as args]]
   (js-apply (eth web3) "sendRawTransaction" args))
 
 (defn send-iban-transaction! [web3 & [signed-transaction-data & args]]

--- a/src/cljs_web3/eth.cljs
+++ b/src/cljs_web3/eth.cljs
@@ -79,6 +79,7 @@
   (js-apply (eth web3) "sendRawTransaction" args))
 
 (defn send-iban-transaction! [web3 & [signed-transaction-data & args]]
+  [web3 & [from iban-address value :as args]]
   (js-apply (eth web3) "sendIBANTransaction" args))
 
 (defn sign [web3 & [address data-to-sign :as args]]

--- a/src/cljs_web3/eth.cljs
+++ b/src/cljs_web3/eth.cljs
@@ -1,129 +1,976 @@
 (ns cljs-web3.eth
+  "Contains the ethereum blockchain related methods."
   (:refer-clojure :exclude [filter])
   (:require [cljs-web3.utils :as u :refer [js-val js-apply]]))
 
-(defn eth [web3]
+
+(defn eth
+  "Gets eth object from web3-instance.
+
+  Parameter:
+  web3 - web3 instance"
+  [web3]
   (aget web3 "eth"))
 
-(defn get-compile [web3]
+
+(defn get-compile
+  "Gets compile object from web3-instance.
+
+  Parameter:
+  web3 - web3 instance"
+  [web3]
   (aget (eth web3) "compile"))
 
-(defn default-account [web3]
+
+(defn default-account
+  "Gets the default address that is used for the following methods (optionally
+  you can overwrite it by specifying the :from key in their options map):
+
+  - `send-transaction!`
+  - `call!`
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns the default address HEX string.
+
+  Example:
+  user> `(default-account web3-instance)`
+  \"0x85d85715218895ae964a750d9a92f13a8951de3d\""
+  [web3]
   (aget web3 "eth" "defaultAccount"))
 
-(defn set-default-account! [web3 hex-str]
+
+(defn set-default-account!
+  "Sets the default address that is used for the following methods (optionally
+  you can overwrite it by specifying the :from key in their options map):
+
+  - `send-transaction!`
+  - `call!`
+
+  Parameters:
+  web3    - web3 instance
+  hex-str - Any 20 bytes address you own, or where you have the private key for
+
+
+  Returns a 20 bytes HEX string representing the currently set address.
+
+  Example:
+  user> (set-default-account! web3-instance
+                              \"0x85d85715218895ae964a750d9a92f13a8951de3d\")
+  \"0x85d85715218895ae964a750d9a92f13a8951de3d\""
+  [web3 hex-str]
   (aset (eth web3) "defaultAccount" hex-str))
 
-(defn default-block [web3]
+
+(defn default-block
+  "This default block is used for the following methods (optionally you can
+  override it by passing the default-block parameter):
+
+  - `get-balance`
+  - `get-code`
+  - `get-transactionCount`
+  - `get-storageAt`
+  - `call`
+  - `contract-call`
+  - `estimate-gas`
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns one of:
+  - a block number
+  - \"earliest\", the genisis block
+  - \"latest\", the latest block (current head of the blockchain)
+  - \"pending\", the currently mined block (including pending transactions)
+
+  Example:
+  user> `(default-block web3-instance)`
+  \"latest\""
+  [web3]
   (aget web3 "eth" "defaultBlock"))
 
-(defn set-default-block! [web3 block]
+
+(defn set-default-block!
+  "Sets default block that is used for the following methods (optionally you can
+  override it by passing the default-block parameter):
+
+  - `get-balance`
+  - `get-code`
+  - `get-transactionCount`
+  - `get-storageAt`
+  - `call`
+  - `contract-call`
+  - `estimate-gas`
+
+  Parameters:
+  web3  - web3 instance
+  block - one of:
+            - a block number
+            - \"earliest\", the genisis block
+            - \"latest\", the latest block (current head of the blockchain)
+            - \"pending\", the currently mined block (including pending
+              transactions)
+
+  Example:
+  user> `(set-default-block! web3-instance \"earliest\")`
+  \"earliest\""
+  [web3 block]
   (aset (eth web3) "defaultBlock" block))
 
-(def syncing (u/prop-or-clb-fn "eth" "syncing"))
+
+(def syncing
+  "This property is read only and returns the either a sync object, when the
+  node is syncing or false.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Returns a sync object as follows, when the node is currently syncing or false:
+  - startingBlock: The block number where the sync started.
+  - currentBlock:  The block number where at which block the node currently
+                   synced to already.
+  - highestBlock:  The estimated block number to sync to.
+
+  Example:
+  user> `(syncing web3-instance (fn [err res] (when-not err (println res))))`
+  nil
+  user> `false`"
+  (u/prop-or-clb-fn "eth" "syncing"))
+
 
 (defn syncing?
+  "This convenience function calls the callback everytime a sync starts, updates
+  and stops.
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns an isSyncing object with the following methods:
+  - `.addCallback`  Adds another callback, which will be called when the node
+                    starts or stops syncing.
+  - `.stopWatching` Stops the syncing callbacks
+
+  Callback return value:
+
+    The callback will be fired with true when the syncing starts and with false
+    when it stopped.
+
+    While syncing it will return the syncing object:
+    - startingBlock: The block number where the sync started.
+    - currentBlock:  The block number where at which block the node currently
+                     synced to already.
+    - highestBlock:  The estimated block number to sync to
+
+  Example:
+  user> `(.addCallback (web3-eth/syncing? web3-instance) (fn [err res] ...))`
+  #object[s [object Object]]"
   [web3 & args]
   (js-apply (eth web3) "isSyncing" args))
 
-(def coinbase (u/prop-or-clb-fn "eth" "coinbase"))
-(def mining? (u/prop-or-clb-fn "eth" "mining"))
-(def hashrate (u/prop-or-clb-fn "eth" "hashrate"))
-(def gas-price (u/prop-or-clb-fn "eth" "gasPrice"))
-(def accounts (u/prop-or-clb-fn "eth" "accounts"))
-(def block-number (u/prop-or-clb-fn "eth" "blockNumber"))
 
-(defn register [web3 address]
+(def coinbase
+  "This property is read only and returns the coinbase address where the mining
+  rewards go to.
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns a string representing the coinbase address of the client.
+
+  Example:
+  user> `(coinbase web3-instance)`
+  \"0x85d85715218895ae964a750d9a92f13a8951de3d\""
+  (u/prop-or-clb-fn "eth" "coinbase"))
+
+
+(def mining?
+  "This property is read only and says whether the node is mining or not.
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns a boolean: true if the client is mining, otherwise false.
+
+  Example:
+  `(mining? web3-instance (fn [err res] (when-not err (println res))))`
+  nil
+  user> `false`"
+  (u/prop-or-clb-fn "eth" "mining"))
+
+
+(def hashrate
+  "This property is read only and returns the number of hashes per second that
+  the node is mining with.
+
+  Parameters:
+  web3 - web3 instance
+
+  Returns a number representing the hashes per second.
+
+  user> `(hashrate web3-instance (fn [err res] (when-not err (println res))))`
+  nil
+  user> 0
+  "
+  (u/prop-or-clb-fn "eth" "hashrate"))
+
+
+(def gas-price
+  "This property is read only and returns the current gas price. The gas price
+  is determined by the x latest blocks median gas price.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Returns a BigNumber instance of the current gas price in wei.
+
+  Example:
+  user> `(gas-price web3-instance (fn [err res] (when-not err (println res))))`
+  nil
+  user> #object[e 90000000000]"
+  (u/prop-or-clb-fn "eth" "gasPrice"))
+
+
+(def accounts
+  "This property is read only and returns a list of accounts the node controls.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Returns an array of addresses controlled by client.
+
+  Example:
+  user> `(accounts web3-instance (fn [err res] (when-not err (println res))))`
+  nil
+  user> `[0x85d85715218895ae964a750d9a92f13a8951de3d]`"
+  (u/prop-or-clb-fn "eth" "accounts"))
+
+
+(def block-number
+  "This property is read only and returns the current block number.
+
+  Parameters:
+  web3        - web3 instance
+  callback-fn - callback with two parameters, error and result
+
+  Returns the number of the most recent block.
+
+  Example:
+  `(block-number web3-instance
+                 (fn [err res] (when-not err (println res))))`
+  nil
+  user> `1783426`"
+  (u/prop-or-clb-fn "eth" "blockNumber"))
+
+
+(defn register
+  "(Not Implemented yet) Registers the given address to be included in
+  `accounts`. This allows non-private-key owned accounts to be associated
+  as an owned account (e.g., contract wallets).
+
+  Parameters:
+  web3        - web3 instance
+  address     - string representing the address
+  callback-fn - callback with two parameters, error and result."
+  [web3 address]
   (js-apply (eth web3) "register" [address]))
 
-(defn unregister [web3 address]
+
+(defn unregister
+  "(Not Implemented yet) Unregisters a given address.
+
+  Parameters:
+  web3        - web3 instance
+  address     - string representing the address
+  callback-fn - callback with two parameters, error and result."
+  [web3 address]
   (js-apply (eth web3) "unRegister" [address]))
 
-(defn get-balance [web3 & [address default-block :as args]]
+
+(defn get-balance
+  "Get the balance of an address at a given block.
+
+  Parameters:
+  web3          - web3 instance
+  address       - The address to get the balance of.
+  default-block - If you pass this parameter it will not use the default block
+                  set with set-default-block.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns a BigNumber instance of the current balance for the given address in
+  wei.
+
+  Example:
+  user> `(get-balance web3-instance
+                      \"0x85d85715218895ae964a750d9a92f13a8951de3d\"
+                      \"latest\"
+                      (fn [err res] (when-not err (println res))))`
+  nil
+  user> #object[e 1729597111000000000]"
+  [web3 & [address default-block :as args]]
   (js-apply (eth web3) "getBalance" args))
 
-(defn get-storage-at [web3 & [address position default-block :as args]]
+
+(defn get-storage-at
+  "Get the storage at a specific position of an address.
+
+  Parameters:
+  web3          - web3 instance
+  address       - The address to get the storage from.
+  position      - The index position of the storage.
+  default-block - If you pass this parameter it will not use the default block
+                  set with web3.eth.defaultBlock.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the value in storage at the given position.
+
+  Example:
+  user> `(get-storage-at web3-instance
+                         \"0x85d85715218895ae964a750d9a92f13a8951de3d\"
+                         0
+                         \"latest\"
+                         (fn [err res] (when-not err (println res))))`
+  nil
+  user> \"0x0000000000000000000000000000000000000000000000000000000000000000\" "
+  [web3 & [address position default-block :as args]]
   (js-apply (eth web3) "getStorageAt" args))
 
-(defn get-code [web3 & [address default-block :as args]]
+
+(defn get-code
+  "Get the code at a specific address.
+
+  Parameters:
+  web3          - web3 instance
+  address       - The address to get the code from.
+  default-block - If you pass this parameter it will not use the default block set
+                  with `get-default-block!`.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the data at given address HEX string.
+
+  Example:
+  user> (get-code web3-instance
+                  \"0x85d85715218895ae964a750d9a92f13a8951de3d\
+                  0
+                  \"latest\"
+                  (fn [err res] (when-not err (println res))))
+  nil
+  user> `0x`"
+  [web3 & [address default-block :as args]]
   (js-apply (eth web3) "getCode" args))
 
-(defn get-block [web3 & [block-hash-or-number return-transaction-objects? :as args]]
+
+(defn get-block
+  "Returns a block matching the block number or block hash.
+
+  Parameters:
+  web3                        - web3 instance
+
+  block-hash-or-number        - The block number or hash. Or the string
+                                \"earliest\", \"latest\" or \"pending\"
+                                as in the default block parameter.
+
+  return-transaction-objects? - If true, the returned block will contain all
+                                transactions as objects, if false it will
+                                only contains the transaction hashes.
+  callback-fn                 - callback with two parameters, error and result
+
+  Returns the block object:
+
+  - number: Number - the block number. null when its pending block.
+  - hash: String, 32 Bytes - hash of the block. null when its pending block.
+  - parent-hash: String, 32 Bytes - hash of the parent block.
+  - nonce: String, 8 Bytes - hash of the generated proof-of-work. null when its
+                             pending block.
+  - sha3-uncles: String, 32 Bytes - SHA3 of the uncles data in the block.
+  - logs-bloom: String, 256 Bytes - the bloom filter for the logs of the block.
+                                   null when its pending block.
+  - transactions-root: String, 32 Bytes - the root of the transaction trie of the
+                                          block
+  - state-root: String, 32 Bytes - the root of the final state trie of the block.
+  - miner: String, 20 Bytes - the address of the beneficiary to whom the mining
+                              rewards were given.
+  - difficulty: BigNumber - integer of the difficulty for this block.
+  - total-difficulty: BigNumber - integer of the total difficulty of the chain
+                                  until this block.
+  - extra- data: String - the \"extra data\" field of this block.
+  - size: Number - integer the size of this block in bytes.
+  - gas- limit: Number - the maximum gas allowed in this block.
+  - gas-used: Number - the total used gas by all transactions in this block.
+  - timestamp: Number - the unix timestamp for when the block was collated.
+  - transactions: Array - Array of transaction objects, or 32 Bytes transaction
+                          hashes depending on the last given parameter.
+  - uncles: Array - Array of uncle hashes.
+
+  Example:
+  user> `(get-block web3-instance
+                    0
+                    false
+                    (fn [err res] (when-not err (println res))))`
+  nil
+  user> {:state-root 0x.., :hash 0x.., :number 0, :difficulty #object[e 1048576],
+         ...}"
+  [web3 & [block-hash-or-number return-transaction-objects? :as args]]
   (js-apply (eth web3) "getBlock" args))
 
-(defn get-block-transaction-count [web3 & [block-hash-or-number :as args]]
-  (eth web3) "getBlockTransactionCount" args)
+
+(defn get-block-transaction-count
+  "Returns the number of transaction in a given block.
+
+  Parameters
+  web3                 - web3 instance
+  block-hash-or-number - The block number or hash. Or the string \"earliest\",
+                         \"latest\" or \"pending\" as in the default block
+                         parameter.
+  callback-fn          - callback with two parameters, error and result
+
+  Example:
+  user> `(get-block-transaction-count
+           web3-instance
+           0
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 0"
   [web3 & [block-hash-or-number :as args]]
   (js-apply (eth web3) "getBlockTransactionCount" args))
 
-(defn get-uncle [web3 & [block-hash-or-number uncle-number return-transaction-objects? :as args]]
+
+(defn get-uncle
+  "Returns a blocks uncle by a given uncle index position.
+  Parameters
+
+  Parameters:
+  web3                        - web3 instance
+  block-hash-or-number        - The block number or hash. Or the string
+                                \"earliest\", \"latest\" or \"pending\" as in
+                                the default block parameter
+  uncle-number                - The index position of the uncle
+  return-transaction-objects? - If true, the returned block will contain all
+                                transactions as objects, if false it will only
+                                contains the transaction hashes
+  default-block               - If you pass this parameter it will not use the
+                                default block set with (set-default-block)
+  callback-fn                 - callback with two parameters, error and result
+
+  Returns the returned uncle. For a return value see `(get-block)`.
+
+  Note: An uncle doesn't contain individual transactions."
+  [web3 & [block-hash-or-number uncle-number return-transaction-objects? :as args]]
   (js-apply (eth web3) "getUncle" args))
 
-(defn get-transaction [web3 & [transaction-hash :as args]]
+
+(defn get-transaction
+ "Returns a transaction matching the given transaction hash.
+
+  Parameters:
+  web3             - web3 instance
+  transaction-hash - The transaction hash.
+  callback-fn      - callback with two parameters, error and result
+
+  Returns a transaction object its hash transaction-hash:
+
+  - hash: String, 32 Bytes - hash of the transaction.
+  - nonce: Number - the number of transactions made by the sender prior to this
+    one.
+  - block-hash: String, 32 Bytes - hash of the block where this transaction was
+                                   in. null when its pending.
+  - block-number: Number - block number where this transaction was in. null when
+                           its pending.
+  - transaction-index: Number - integer of the transactions index position in the
+                                block. null when its pending.
+  - from: String, 20 Bytes - address of the sender.
+  - to: String, 20 Bytes - address of the receiver. null when its a contract
+                           creation transaction.
+  - value: BigNumber - value transferred in Wei.
+  - gas-price: BigNumber - gas price provided by the sender in Wei.
+  - gas: Number - gas provided by the sender.
+  - input: String - the data sent along with the transaction.
+
+  Example:
+  user> `(get-transaction
+           web3-instance
+           \"0x...\"
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> {:r 0x...
+         :v 0x2a
+         :hash 0xf...
+         :transaction-index 3 ...
+         (...)
+         :to 0x...}"
+  [web3 & [transaction-hash :as args]]
   (js-apply (eth web3) "getTransaction" args))
 
-(defn get-transaction-from-block [web3 & [block-hash-or-number index :as args]]
+
+(defn get-transaction-from-block
+  "Returns a transaction based on a block hash or number and the transactions
+  index position.
+
+  Parameters:
+  web3                 - web3 instance
+  block-hash-or-number - A block number or hash. Or the string \"earliest\",
+                         \"latest\" or \"pending\" as in the default block
+                         parameter.
+  index                - The transactions index position.
+  callback-fn          - callback with two parameters, error and result
+  Number               - The transactions index position.
+
+  Returns a transaction object, see `(get-transaction)`
+
+  Example:
+  user> `(get-transaction-from-block
+           web3-instance
+           1799402
+           0
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> {:r 0x...
+         :v 0x2a
+         :hash 0xf...
+         :transaction-index 0 ...
+         (...)
+         :to 0x...}"
+  [web3 & [block-hash-or-number index :as args]]
   (js-apply (eth web3) "getTransactionFromBlock" args))
 
-(defn get-transaction-receipt [web3 & [transaction-hash :as args]]
+
+(defn get-transaction-receipt
+  "Returns the receipt of a transaction by transaction hash.
+
+  Note That the receipt is not available for pending transactions.
+
+  Parameters:
+  web3              - web3 instance
+  transaction-hash  - The transaction hash.
+  callback-fn       - callback with two parameters, error and result
+
+  Returns transaction receipt object, or null when no receipt was found:
+
+  - blockHash: String, 32 Bytes - hash of the block where this transaction was
+                                  in.
+  - blockNumber: Number - block number where this transaction was in.
+  - transactionHash: String, 32 Bytes - hash of the transaction.
+  - transactionIndex: Number - integer of the transactions index position in the
+                               block.
+  - from: String, 20 Bytes - address of the sender.
+  - to: String, 20 Bytes - address of the receiver. null when its a contract
+                           creation transaction.
+  - cumulativeGasUsed: Number - The total amount of gas used when this
+                                transaction was executed in the block.
+  - gasUsed: Number - The amount of gas used by this specific transaction alone.
+  - contractAddress: String - 20 Bytes - The contract address created, if the
+                                         transaction was a contract creation,
+                                         otherwise null.
+  - logs: Array - Array of log objects, which this transaction generated.
+
+  Example"
+  [web3 & [transaction-hash :as args]]
   (js-apply (eth web3) "getTransactionReceipt" args))
 
-(defn get-transaction-count [web3 & [address default-block :as args]]
+
+(defn get-transaction-count
+  "Get the numbers of transactions sent from this address.
+
+  Parameters:
+  web3          - web3 instance
+  address       - The address to get the numbers of transactions from.
+  default-block - If you pass this parameter it will not use the default block
+                  set with set-default-block.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the number of transactions sent from the given address.
+
+  Example:
+  user> `(get-transaction-count web3-instance \"0x8\"
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 16"
+  [web3 & [address default-block :as args]]
   (js-apply (eth web3) "getTransactionCount" args))
 
-(defn send-transaction! [web3 & [transaction-object :as args]]
+
+(defn send-transaction!
+  "Sends a transaction to the network.
+
+  Parameters:
+  web3               - web3 instance
+  transaction-object - The transaction object to send:
+
+    :from: String - The address for the sending account. Uses the
+                    `default-account` property, if not specified.
+
+    :to: String   - (optional) The destination address of the message, left
+                               undefined for a contract-creation
+                               transaction.
+
+    :value        - (optional) The value transferred for the transaction in
+                               Wei, also the endowment if it's a
+                               contract-creation transaction.
+
+    :gas:         - (optional, default: To-Be-Determined) The amount of gas
+                    to use for the transaction (unused gas is refunded).
+    :gas-price:   - (optional, default: To-Be-Determined) The price of gas
+                    for this transaction in wei, defaults to the mean network
+                    gas price.
+    :data:        - (optional) Either a byte string containing the associated
+                    data of the message, or in the case of a contract-creation
+                    transaction, the initialisation code.
+    :nonce:       - (optional) Integer of a nonce. This allows to overwrite your
+                               own pending transactions that use the same nonce.
+  callback-fn   - callback with two parameters, error and result, where result
+                  is the transaction hash
+
+  Returns the 32 Bytes transaction hash as HEX string.
+
+  If the transaction was a contract creation use `(get-transaction-receipt)` to
+  get the contract address, after the transaction was mined.
+
+  Example:
+  user> (send-transaction! web3-instance {:to \"0x..\"}
+          (fn [err res] (when-not err (println res))))
+  nil
+  user> 0x..."
+  [web3 & [transaction-object :as args]]
   (js-apply (eth web3) "sendTransaction" args))
 
-(defn send-raw-transaction! [web3 & [signed-transaction-data & args]]
+
+(defn send-raw-transaction!
+  "Sends an already signed transaction. For example can be signed using:
+  https://github.com/SilentCicero/ethereumjs-accounts
+
+  Parameters:
+  web3                    - web3 instance
+  signed-transaction-data - Signed transaction data in HEX format
+
+  callback-fn             - callback with two parameters, error and result
+
+  Returns the 32 Bytes transaction hash as HEX string.
+
+  If the transaction was a contract creation use `(get-transaction-receipt)`
+  to get the contract address, after the transaction was mined.
+
+  See https://github.com/ethereum/wiki/wiki/JavaScript-API#example-46 for a
+  JavaScript example."
   [web3 & [signed-transaction-data :as args]]
   (js-apply (eth web3) "sendRawTransaction" args))
 
-(defn send-iban-transaction! [web3 & [signed-transaction-data & args]]
+
+(defn send-iban-transaction!
+  "Sends IBAN transaction from user account to destination IBAN address.
+
+  Parameters:
+  web3          - web3 instance
+  from          - address from which we want to send transaction
+  iban-address  - IBAN address to which we want to send transaction
+  value         - value that we want to send in IBAN transaction
+  callback-fn   - callback with two parameters, error and result
+
+  Note: uses smart contract to transfer money to IBAN account.
+
+  Example:
+  user> `(send-iban-transaction! '0xx'
+                                 'NL88YADYA02'
+                                  0x100
+                                  (fn [err res] (prn res)))`"
   [web3 & [from iban-address value :as args]]
   (js-apply (eth web3) "sendIBANTransaction" args))
 
-(defn sign [web3 & [address data-to-sign :as args]]
+(defn sign
+  "Signs data from a specific account. This account needs to be unlocked.
+
+  Parameters:
+  web3          - web3 instance
+  address       - The address to sign with
+  data-to-sign  - Data to sign
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the signed data.
+
+  After the hex prefix, characters correspond to ECDSA values like this:
+
+  r = signature[0:64]
+  s = signature[64:128]
+  v = signature[128:130]
+
+  Note that if you are using ecrecover, v will be either \"00\" or \"01\". As a
+  result, in order to use this value, you will have to parse it to an integer
+  and then add 27. This will result in either a 27 or a 28.
+
+  Example:
+  user> `(sign web3-instance
+               \"0x135a7de83802408321b74c322f8558db1679ac20\"
+               \"0x9dd2c369a187b4e6b9c402f030e50743e619301ea62aa4c0737d4ef7e10a3d49\"
+               (fn [err res] (when-not err (println res))))`
+
+  user> 0x3..."
+  [web3 & [address data-to-sign :as args]]
   (js-apply (eth web3) "sign" args))
 
-(defn sign-transaction [web3 & args]
+
+(defn sign-transaction
+  "Sign a transaction. Method is not documented in the web3.js docs. Not sure if it is safe.
+
+  Parameters:
+  web3           - web3 instance
+  sign-tx-params - Parameters of transaction
+                   See `(send-transaction!)`
+  private-key    - Private key to sign the transaction with
+  callback-fn    - callback with two parameters, error and result
+
+  Returns signed transaction data."
+  [web3 & [sign-tx-params private-key signed-tx :as args]]
   (js-apply (eth web3) "signTransaction" args))
 
-(defn call! [web3 & [call-object default-block :as args]]
+
+(defn call!
+  "Executes a message call transaction, which is directly executed in the VM of
+  the node, but never mined into the blockchain.
+
+  Parameters:
+  web3          - web3 instance
+  call-object   - A transaction object see web3.eth.sendTransaction, with the
+                  difference that for calls the from property is optional as
+                  well.
+  default-block - If you pass this parameter it will not use the default block
+                  set with set-default-block.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the returned data of the call as string, e.g. a codes functions return
+  value.
+
+  Example:
+  user> `(call! web3-instance {:to   \"0x\"
+                               :data \"0x\"}
+                (fn [err res] (when-not err (println res))))`
+  nil
+  user> 0x"
+  [web3 & [call-object default-block :as args]]
   (js-apply (eth web3) "call" args))
 
-(defn estimate-gas [web3 & [call-obejct :as args]]
+
+(defn estimate-gas
+
+  "Executes a message call or transaction, which is directly executed in the VM
+  of the node, but never mined into the blockchain and returns the amount of the
+  gas used.
+
+  Parameters:
+  web3          - web3 instance
+  call-object   - See `(send-transaction!)`, except that all properties are
+                  optional.
+  callback-fn   - callback with two parameters, error and result
+
+  Returns the used gas for the simulated call/transaction.
+
+  Example:
+  user> `(estimate-gas web3-instance
+           {:to   \"0x135a7de83802408321b74c322f8558db1679ac20\",
+            :data \"0x135a7de83802408321b74c322f8558db1679ac20\"}
+           (fn [err res] (when-not err (println res))))`
+  nil
+  user> 22361"
+  [web3 & [call-object :as args]]
+
   (js-apply (eth web3) "estimateGas" args))
 
-(defn filter [web3 & args]
+
+(defn filter
+  "Parameters:
+  web3          - web3 instance
+  block-or-transaction  - The string \"latest\" or \"pending\" to watch
+                          for changes in the latest block or pending
+                          transactions respectively. Or a filter options
+                          object as follows:
+
+    from-block: Number|String - The number of the earliest block (latest may be
+                                given to mean the most recent and pending
+                                currently mining, block). By default
+                               latest.
+    to-block: Number|String   - The number of the latest block (latest may be
+                                given to mean the most recent and pending
+                                currently mining, block). By default latest.
+
+    address: String           - An address or a list of addresses to only get
+                                logs from particular account(s).
+
+    :topics: Array of Strings - An array of values which must each appear in the
+                                log entries. The order is important, if you want
+                                to leave topics out use null, e.g.
+                                `[null, '0x00...']`. You can also pass another array
+                                for each topic with options for that topic e.g.
+                                `[null, ['option1', 'option2']]`
+
+  Returns a filter object with the following methods:
+
+    `(.get filter callback-fn)`:   Returns all of the log entries that fit the
+                                   filter.
+    `(.watch filter callback-fn)`: Watches for state changes that fit the
+                                   filter and calls the callback.
+    `(.stopWatching filter)`:      Stops the watch and uninstalls the filter in the
+                                   node. Should always be called once it is done.
+
+  Watch callback return value
+
+    String - When using the \"latest\" parameter, it returns the block hash of
+             the last incoming block.
+
+    String - When using the \"pending\" parameter, it returns a transaction hash
+             of the most recent pending transaction.
+    Object - When using manual filter options, it returns a log object as follows:
+
+        logIndex: Number - integer of the log index position in the block. null
+                           when its pending log.
+        transactionIndex: Number - integer of the transactions index position log
+                                   was created from. null when its pending log.
+        transactionHash: String, 32 Bytes - hash of the transactions this log was
+                                            created from. null when its pending log.
+        blockHash: String, 32 Bytes - hash of the block where this log was in. null
+                                      when its pending. null when its pending log.
+        blockNumber: Number - the block number where this log was in. null when its
+                              pending. null when its pending log.
+        address: String, 32 Bytes - address from which this log originated.
+        data: String - contains one or more 32 Bytes non-indexed arguments of the log.
+
+        topics: Array of Strings - Array of 0 to 4 32 Bytes DATA of indexed log
+                                   arguments. (In solidity: The first topic is the hash
+                                   of the signature of the event, except if you declared the
+                                   event with the anonymous specifier.)
+
+  Note for event filter return values see Contract Events at
+  https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events"
+  [web3 & args]
   (js-apply (eth web3) "filter" args))
 
-(defn get-compilers [web3 & args]
+
+(defn get-compilers
+  "Compiling features being deprecated https://github.com/ethereum/EIPs/issues/209"
+  [web3 & args]
   (js-apply (eth web3) "getCompilers" args))
 
-(defn compile-solidity [web3 & [source-string :as args]]
+
+(defn compile-solidity
+  "Compiling features being deprecated https://github.com/ethereum/EIPs/issues/209"
+  [web3 & [source-string :as args]]
   (js-apply (get-compile web3) "solidity" args))
 
-(defn compile-lll [web3 & [source-string :as args]]
+
+(defn compile-lll
+  "Compiling features being deprecated https://github.com/ethereum/EIPs/issues/209"
+  [web3 & [source-string :as args]]
   (js-apply (get-compile web3) "lll" args))
 
-(defn compile-serpent [web3 & [source-string :as args]]
+
+(defn compile-serpent
+  "Compiling features being deprecated https://github.com/ethereum/EIPs/issues/209"
+  [web3 & [source-string :as args]]
   (js-apply (get-compile web3) "serpent" args))
 
-(defn namereg [web3]
+
+(defn namereg
+  "Returns GlobalRegistrar object.
+
+  See https://github.com/ethereum/web3.js/blob/master/example/namereg.html
+  for an example in JavaScript."
+  [web3]
   (aget (eth web3) "namereg"))
 
-(defn contract [web3 & [abi :as args]]
+
+(defn contract
+  "Creates a contract object for a solidity contract, which can be used to
+  initiate contracts on an address.
+
+  Parameters:
+  web3          - web3 instance
+  abi           - ABI array with descriptions of functions and events of
+                  the contract
+  callback-fn   - callback with two parameters, error and result
+
+  Returns a contract object."
+  [web3 & [abi :as args]]
   (js-apply (eth web3) "contract" args))
 
-(defn contract-at [web3 abi & args]
+
+(defn contract-at
+  "Initiate an existing contract on an address.
+
+  Parameters:
+  web3          - web3 instance
+  abi           - ABI array with descriptions of functions and events of
+                  the contract
+  address       - The address of the existing contract
+
+  Example:
+  user> `(contract-at web3-instance
+                      abi
+                      address)`"
+  [web3 abi & [address :as args]]
   (js-apply (contract web3 abi) "at" args))
 
-(defn contract-new [web3 abi & args]
+
+(defn contract-new
+  "Deploy a contract asynchronous from a Solidity file.
+
+  Parameters:
+  web3             - web3 instance
+  abi              - ABI array with descriptions of functions and events of
+                     the contract
+  transaction-data - map that contains
+    - :gas - max gas to use
+    - :data the BIN of the contract
+    - :from account to use
+  callback-fn      - callback with two parameters, error and contract.
+                     From the contract the \"address\" property can be used to
+                     obtain the address. And the \"transactionHash\" to obtain
+                     the hash of the transaction, which created the contract.
+
+  Example:
+  `(contract-new web3-instance
+                 abi
+                 {:from \"0x..\"
+                  :data bin
+                  :gas  4000000}
+                 (fn [err contract]
+                   (if-not err
+                    (let [address (aget contract \"address\")
+                          tx-hash (aget contract \"transactionHash\")]
+                      ;; Two calls: transaction received
+                      ;; and contract deployed.
+                      ;; Check address on the second call
+                      (when (address? address)
+                        (do-something-with-contract contract)
+                        (do-something-with-address address)))
+                    (println \"error deploying contract\" err))))`
+   nil"
+  [web3 abi & [transaction-data callback-fn :as args]]
   (js-apply (contract web3 abi) "new" args))
 
-(defn contract-call [contract-instance method & args]
+
+(defn contract-call
+  "Explicitly call a method on a contract.
+
+  Use the kebab-cases version of the original method.
+  E.g., function fooBar() can be addressed with :foo-bar.
+
+  Parameters:
+  contract-instance - an instance of the contract (obtained via `contract` or
+                      `contract-at`)
+  method            - the kebab-cased version of the method
+  args              - arguments to the method
+
+  Example:
+  user> `(web3-eth/contract-call ContractInstance :multiply 5)`
+  25"
+  [contract-instance method & args]
   (js-apply contract-instance method args))
 
-(defn stop-watching! [filter & args]
-  (js-apply filter "stopWatching" args))
 
+(defn stop-watching!
+  "Stops and uninstalls the filter.
+
+  Arguments:
+  filter - the filter to stop"
+  [filter & args]
+  (js-apply filter "stopWatching" args))

--- a/src/cljs_web3/evm.cljs
+++ b/src/cljs_web3/evm.cljs
@@ -1,14 +1,40 @@
-;;   Functions in this namespace are possible to use only with testrpc
 (ns cljs-web3.evm
+  "Functions that can be used to control testrpc behaviour. Can ONLY (!) be used
+  with testrpc.
+
+  See https://github.com/ethereumjs/testrpc for more information."
   (:require [cljs-web3.utils :refer [callback-js->clj]]))
 
-(defn send-async-fn [web3]
+
+(defn send-async-fn
+  "Creates an fn that sends asynchronous function to the currentProvider.
+
+  Parameter:
+  web3 - web3 instance
+
+  Example:
+  user> `(send-async-fn web3)`
+  #object..."
+  [web3]
   (fn [& args]
     (apply js-invoke
            (aget web3 "currentProvider")
            "sendAsync" args)))
 
-(defn increase-time! [web3 args callback]
+
+(defn increase-time!
+  "Jump forward in time in the EVM.
+
+  Parameters:
+  web3     - web3 instance
+  args     - The amount of time to increase in seconds.
+  callback - callback with two parameters, error and result.
+
+  Returns the total time adjustment, in seconds.
+
+  Example:
+  user> `(web3-evm/increase-time! web3 [1000] callback)`"
+  [web3 args callback]
   ((send-async-fn web3)
     (clj->js {:jsonrpc "2.0"
               :method "evm_increaseTime"
@@ -16,7 +42,18 @@
               :id (.getTime (js/Date.))})
     (callback-js->clj callback)))
 
-(defn mine! [web3 callback]
+
+(defn mine!
+  "Force a block to be mined. Mines a block independent of
+  whether or not mining is started or stopped.
+
+  Parameters:
+  web3     - web3 instance
+  callback - callback with two parameters, error and result.
+
+  Example:
+  user> `(web3-evm/mine! web3 callback)`"
+  [web3 callback]
   ((send-async-fn web3)
     (clj->js {:jsonrpc "2.0"
               :method "evm_mine"
@@ -24,7 +61,25 @@
               :id (.getTime (js/Date.))})
     (callback-js->clj callback)))
 
-(defn revert! [web3 args callback]
+
+(defn revert!
+  "Revert the state of the blockchain to a previous snapshot.
+
+  Takes a single
+  parameter, which is the snapshot id to revert to. If no snapshot id is passed
+  it will revert to the latest snapshot. Returns true.
+
+  Parameters:
+  web3     - web3 instance
+  args     - snapshot id to revert to, if no snapshot id is passed, it will
+             revert to the latest snapshot
+  callback - callback with two parameters, error and result.
+
+  Returns true.
+
+  Example:
+  user> `(web3-evm/revert! web3 0 callback)`"
+  [web3 args callback]
   ((send-async-fn web3)
     (clj->js {:jsonrpc "2.0"
               :method "evm_revert"
@@ -32,7 +87,20 @@
               :id (.getTime (js/Date.))})
     (callback-js->clj callback)))
 
-(defn snapshot! [web3 callback]
+
+(defn snapshot!
+  "Snapshot the state of the blockchain at the current block.
+
+  Parameters:
+  web3     - web3 instance
+  callback - callback with two parameters, error and result.
+
+  Returns the integer id of the snapshot created.
+
+  Example:
+  user> `(web3-evm/snapshot! web3 callback)`
+  0"
+  [web3 callback]
   ((send-async-fn web3)
     (clj->js {:jsonrpc "2.0"
               :method "evm_snapshot"

--- a/src/cljs_web3/net.cljs
+++ b/src/cljs_web3/net.cljs
@@ -1,5 +1,32 @@
 (ns cljs-web3.net
   (:require [cljs-web3.utils :as u]))
 
-(def listening? (u/prop-or-clb-fn "net" "listening"))
-(def peer-count (u/prop-or-clb-fn "net" "peerCount"))
+
+(def listening?
+
+  "This property is read only and says whether the node is actively
+  listening for network connections or not.
+
+  Parameters:
+  callback - callback with two parameters: error and result
+
+  Returns true if the client is actively listening for network connections,
+  otherwise false.
+
+  Example:
+  user> `(listening? (fn [err res] (when-not err (println res))))`
+  nil
+  user> true"
+  (u/prop-or-clb-fn "net" "listening"))
+
+
+(def peer-count
+  "This property is read only and returns the number of connected peers.
+
+  Returns the number of peers currently connected to the client.
+
+  Example:
+  user> `(peer-count (fn [err res] (when-not err (println res))))`
+  nil
+  user> 4"
+  (u/prop-or-clb-fn "net" "peerCount"))

--- a/src/cljs_web3/personal.cljs
+++ b/src/cljs_web3/personal.cljs
@@ -1,31 +1,156 @@
 (ns cljs-web3.personal
+  "The web3-eth-personal package allows you to interact with the Ethereum node’s
+  accounts."
   (:require [cljs-web3.utils :as u :refer [js-apply]]))
 
-(defn get-prs [web3]
+
+(defn get-prs
+  "Get the web3-eth-personal package.
+
+  Parameter:
+  web3 - web3 instance"
+  [web3]
   (aget web3 "personal"))
 
-(def list-accounts (u/prop-or-clb-fn "personal" "listAccounts"))
 
-(defn lock-account [web3 & args]
+(def list-accounts
+  "List accounts available.
+
+  Parameter:
+  web3 - web3 instance
+
+  Returns all the Ethereum account addresses of all keys in the key store.
+
+  Example:
+  user> `(list-accounts web3-instance)`
+  [\"0x5e97870f263700f46aa00d967821199b9bc5a120\",
+   \"0x3d80b31a78c30fc628f20b2c89d7ddbf6e53cedc\"]"
+  (u/prop-or-clb-fn "personal" "listAccounts"))
+
+
+(defn lock-account
+  "Removes the private key with given address from memory. The account can no
+  longer be used to send transactions.
+
+  Parameters:
+  web3    - web3 instance
+  address - address to lock"
+  [web3 & args]
   (js-apply (get-prs web3) "lockAccount" args))
 
-(defn new-account [web3 & args]
+
+(defn new-account
+  "Creates a new account.
+
+  Note: Never call this function over a unsecured Websocket or HTTP provider, as
+  your password will be send in plain text!
+
+  Parameters:
+  web3 - web3 instance
+  password - String: The password to encrypt this account with.
+
+  Returns:
+  Promise returns Boolean: true if the account was created, otherwise
+  false."
+  [web3 & args]
   (js-apply (get-prs web3) "newAccount" args))
 
-(defn unlock-account [web3 & args]
+
+(defn unlock-account
+  "Unlocks the given account for duration seconds.
+
+  Parameters:
+  web3       - web3 instance
+  address    - address to unlock
+  passphrase - passphrase
+  duration   - time to unlock for in seconds, 0 for indefinitely
+  callback   - callback with error and result parameters
+
+  Returns boolean as to whether the account was successfully unlocked.
+
+  Example:
+  user> `(web3-personal/unlock-account web3-instance
+                                   account
+                                   \"password\"
+                                   indefinitely
+                                   callback)`"
+  [web3 & args]
   (js-apply (get-prs web3) "unlockAccount" args))
 
-(defn ec-recover [web3 & args]
+
+(defn ec-recover
+  "Recovers the Ethereum address which was used to sign the given data.
+
+  Parameters:
+  web3 - web3 instance
+  signature - String|Object: Either the encoded signature, the v, r, s values as
+                             separate parameters, or an object with the following
+                             values:
+      messageHash - String: The hash of the given message.
+      r - String: First 32 bytes of the signature
+      s - String: Next 32 bytes of the signature
+      v - String: Recovery value + 27
+
+  Returns the Ethereum address used to sign this data."
+  [web3 & args]
   (js-apply (get-prs web3) "ecRecover" args))
 
-(defn import-raw-key [web3 & args]
+
+(defn import-raw-key
+  "Imports the given unencrypted private key (hex string) into the key store,
+  encrypting it with the passphrase.
+
+  Parameters:
+  web3       - web3 instance
+  keydata    - hex string representing the unencrypted private key
+  passphrase - passphrase
+  callback   - callback with error and result as parameters
+
+  Returns the address of the new account."
+  [web3 & args]
   (js-apply (get-prs web3) "importRawKey" args))
 
-(defn send-transaction [web3 & args]
+
+(defn send-transaction
+  "Validate the given passphrase and submit transaction.
+
+  Parameters:
+  web3        - web3 instance
+  transaction - The same argument as for `(web3-eth/send-transaction! ...)`
+                and contains the from address. If the passphrase can be
+                used to decrypt the private key belogging to tx.from the
+                transaction is verified, signed and send onto the network.
+                The account is not unlocked globally in the node and cannot
+                be used in other RPC calls.
+  passphrase  - passphrase
+  callback    - callback with error and result as parameters
+
+  Example:
+  user> `(send-transaction web3-instance
+           {:from \"0x...\"
+            :to   \"0x\"}
+          \"password\"
+         callback)`"
+  [web3 & args]
   (js-apply (get-prs web3) "sendTransaction" args))
 
-(defn sign [web3 & args]
+
+(defn sign
+  "Signs data using a specific account.
+
+  Note: Sending your account password over an unsecured HTTP RPC connection is
+  highly unsecure.
+
+  Parameters:
+  web3     - web3 insance
+  String   - Data to sign. If String it will be converted using
+             web3.utils.utf8ToHex.
+  String   - Address to sign data with.
+  String   - The password of the account to sign data with.
+  Function - (optional) Optional callback, returns an error object as first
+                        parameter and the result as second.
+
+  Returns:
+  Promise returns String - The signature."
+  [web3 & args]
   (js-apply (get-prs web3) "sign" args))
-
-
-

--- a/src/cljs_web3/settings.cljs
+++ b/src/cljs_web3/settings.cljs
@@ -1,5 +1,4 @@
-(ns cljs-web3.settings
-  (:require [cljs-web3.utils :as u :refer [js-val js-apply]]))
+(ns cljs-web3.settings)
 
 (defn settings [web3]
   (aget web3 "settings"))

--- a/src/cljs_web3/shh.cljs
+++ b/src/cljs_web3/shh.cljs
@@ -1,21 +1,77 @@
 (ns cljs-web3.shh
+  "The web3-shh package allows you to interact with an the whisper protocol for
+  broadcasting. For more see Whisper Overview at
+  https://github.com/ethereum/go-ethereum/wiki/Whisper."
   (:refer-clojure :exclude [filter])
   (:require [cljs-web3.utils :as u :refer [js-apply]]))
 
-(defn get-shh [web3]
+
+(defn get-shh
+  "Obtain Whisper package from web3 object
+
+  Parameters:
+  web3 - web3 instance"
+  [web3]
   (aget web3 "shh"))
 
-(defn post! [web3 & args]
+
+(defn post!
+  "This method should be called, when we want to post whisper a message to the
+  network.
+
+  Parameters:
+  web3 - web3 instance
+  data - The post object:
+            :sym-key-id - String (optional): ID of symmetric key for message
+                                             encryption (Either symKeyID or
+                                             pubKey must be present. Cannot be both.)
+
+            :pub-key - String (optional): The public key for message
+                                          encryption (Either symKeyID or pubKey must
+                                          be present. Cannot be both.)
+            :sig - String (optional): The ID of the signing key.
+            :ttl - Number: Time-to-live in seconds.
+            :topic - String: 4 Bytes (mandatory when key is symmetric): Message
+                                                                        topic.
+            :payload - String: The payload of the message to be encrypted.
+            :padding - Number (optional): Padding (byte array of arbitrary
+                                          length).
+            :pow-time - Number (optional)?: Maximal time in seconds to be spent on
+                                            proof of work.
+            :pow-target - Number (optional)?: Minimal PoW target required for this
+                                              message.
+            :target-peer - Number (optional): Peer ID (for peer-to-peer message only).
+    callback - Function: (optional) Optional callback, returns an error object
+                                    as first parameter and the result as second.
+
+  Returns:
+  Boolean - returns true if the message was send, otherwise false or error.
+
+  JavaScript example: http://web3js.readthedocs.io/en/1.0/web3-shh.html#id74"
+  [web3 & args]
   (js-apply (get-shh web3) "post" args))
 
-(defn new-identity [web3 & args]
+
+(defn new-identity
+  "Seems deprecated since no JavaScript documentation available at
+  http://web3js.readthedocs.io/en/1.0/web3-shh.html"
+  [web3 & args]
   (js-apply (get-shh web3) "newIdentity" args))
 
-(defn has-identity? [web3 & args]
+(defn has-identity?
+  "Seems deprecated since no JavaScript documentation available at
+  http://web3js.readthedocs.io/en/1.0/web3-shh.html"
+  [web3 & args]
   (js-apply (get-shh web3) "hasIdentity" args))
 
-(defn new-group [web3 & args]
+(defn new-group
+  "Seems deprecated since no JavaScript documentation available at
+  http://web3js.readthedocs.io/en/1.0/web3-shh.html"
+  [web3 & args]
   (js-apply (get-shh web3) "newGroup" args))
 
-(defn add-to-group [web3 & args]
+(defn add-to-group
+  "Seems deprecated since no JavaScript documentation available at
+  http://web3js.readthedocs.io/en/1.0/web3-shh.html"
+  [web3 & args]
   (js-apply (get-shh web3) "addToGroup" args))

--- a/src/cljs_web3/utils.cljs
+++ b/src/cljs_web3/utils.cljs
@@ -6,12 +6,6 @@
     [cljs.core.async :refer [>! chan]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-(defn js-val [clj-or-js-dict]
-  (cond
-    (map? clj-or-js-dict) (clj->js clj-or-js-dict)
-    (vector? clj-or-js-dict) (clj->js clj-or-js-dict)
-    :else clj-or-js-dict))
-
 (defn safe-case [case-f]
   (fn [x]
     (cond-> (subs (name x) 1)

--- a/src/cljs_web3/utils.cljs
+++ b/src/cljs_web3/utils.cljs
@@ -1,9 +1,8 @@
 (ns cljs-web3.utils
-  (:require
-    [camel-snake-kebab.core :as cs :include-macros true]
-    [camel-snake-kebab.extras :refer [transform-keys]]
-    [clojure.string :as string]
-    [cljs.core.async :refer [>! chan]])
+  (:require [camel-snake-kebab.core :as cs :include-macros true]
+            [camel-snake-kebab.extras :refer [transform-keys]]
+            [cljs.core.async :refer [>! chan]]
+            [clojure.string :as string])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
 (defn safe-case [case-f]
@@ -20,9 +19,13 @@
 
 (def js->cljk #(js->clj % :keywordize-keys true))
 
-(def js->cljkk (comp (partial transform-keys kebab-case) js->cljk))
+(def js->cljkk
+  "From JavaScript to Clojure with kekab-cased keywords."
+  (comp (partial transform-keys kebab-case) js->cljk))
 
-(def cljkk->js (comp clj->js (partial transform-keys camel-case)))
+(def cljkk->js
+  "From Clojure with kebab-cased keywords to JavaScript."
+  (comp clj->js (partial transform-keys camel-case)))
 
 (defn callback-js->clj [x]
   (if (fn? x)
@@ -45,10 +48,15 @@
 (defn js-prototype-apply [js-obj method-name args]
   (js-apply (aget js-obj "prototype") method-name args))
 
-(defn prop-or-clb-fn [& ks]
+(defn prop-or-clb-fn
+  "Constructor to create an fn to get properties or to get properties and apply a
+  callback fn."
+  [& ks]
   (fn [web3 & args]
     (if (fn? (first args))
-      (js-apply (apply aget web3 (butlast ks)) (str "get" (cs/->PascalCase (last ks))) args)
+      (js-apply (apply aget web3 (butlast ks))
+                (str "get" (cs/->PascalCase (last ks)))
+                args)
       (js->cljkk (apply aget web3 ks)))))
 
 (defn create-async-fn [f]
@@ -56,7 +64,6 @@
     (let [[ch args] (if (instance? cljs.core.async.impl.channels/ManyToManyChannel (first args))
                       [(first args) (rest args)]
                       [(chan) args])]
-
       (apply f (concat args [(fn [err res]
                                (go (>! ch [err res])))]))
       ch)))


### PR DESCRIPTION
Hi Matúš,

I have added docstrings to this library (adjusted from the web3.js documentation) so that you do not need to go to the web3.js docs to find out how methods work. There were also some things that did not line up with the underlying methods in web3.

Changes:

## README
Slightly improve text of README
- Clojurescript -> ClojureScript
- Sort namespaces
- Add articles like "the" and "a" where needed
Add link to web3.js docs

## Docstrings and functions
Add docstrings based on Web3 API docs to core
Add docstrings to db
Add docstrings to web3-eth methods and namespace
Add docstrings to web3-evm ns and functions
Docstrings for functions in web3-net
Docstrings for functions and ns in web3-personal
Docstrings for ns and functions in web3-ssh
Utils docstrings
Add docstring to cljs-web3.bzz namespace

## Fixes
fix parameters in send-iban-transaction!
fix: use :as args instead of & args (We want to pass all arguments to js-apply)
fix: use js-apply in get-block-transaction-count
- Also mention some bugs (in docstring)
- Add examples
- Add `keep-is-syncing?` parameter to `reset`

## Cleanup
Remove unused method js-val

Note: it looks like the web3-settings namespace's functions do not exist on web. So I believe the namespace can be removed.

Hope this helps.