### PR TITLE
Add [print-foo-cljs "2.0.3"] to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Docstrings for the methods and namespaces are adjusted to ClojureScript from the
 
 ## Testing
 
-1. Run figwheel `lein figwheel`
+1. Start figwheel `lein figwheel`
 2. Open http://localhost:6612/ in the browser
-3. Run `(cljs-web3.run-tests/run-all-tests)` inside cljs repl.
+3. Run `testrpc -p 8549` (Install testrpc with `npm install -g ethereumjs-testrpc` https://github.com/ethereumjs/testrpc)
+4. Run `(cljs-web3.run-tests/run-all-tests)` inside cljs repl.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,9 @@ Docstrings for the methods and namespaces are adjusted to ClojureScript from the
 ## DAPPS using cljs-web3
 * [emojillionaire](https://github.com/madvas/emojillionaire)
 * [ethlance](https://github.com/madvas/ethlance)
+
+## Testing
+
+1. Run figwheel `lein figwheel`
+2. Open http://localhost:6612/ in the browser
+3. Run `(cljs-web3.run-tests/run-all-tests)` inside cljs repl.

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojurescript "1.9.227"]
                  [camel-snake-kebab "0.4.0"]
+                 [print-foo-cljs "2.0.3"]
                  [cljsjs/web3 "0.19.0-0"]]
   :plugins [[lein-cljsbuild "1.1.4"]]
 


### PR DESCRIPTION
Adding "print-foo-cljs" dependency in order to run tests.